### PR TITLE
feat: remove windows support and git user sync

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -2,16 +2,12 @@ import { existsSync } from 'node:fs';
 import {
   copyFile,
   mkdir,
-  readdir,
   readFile,
   rm,
-  stat,
   unlink,
-  writeFile,
+  writeFile
 } from 'node:fs/promises';
-import { EOL } from 'node:os';
 import { join } from 'node:path';
-import { vote } from './siblings.js';
 
 const dirs = ['.vscode'];
 const files = [
@@ -84,83 +80,10 @@ export async function setup(targetDir: string) {
     }
     await copyFile(join('template', file), join(targetDir, file));
   }
-  await syncGitUser(targetDir);
-  await makeWindowsDevcontainerFriendly(targetDir);
-}
-
-async function syncGitUser(path: string) {
-  try {
-    const [ws, core, ...sections] = (
-      await readFile(join(path, '.git/config'), 'utf-8')
-    )
-      .split('[')
-      .map((s) => '[' + s);
-    if (!ws || !core || sections[0]?.startsWith('[user]')) {
-      return;
-    }
-    const user = await vote(
-      path,
-      '.git/config',
-      (content) =>
-        '[' +
-        content
-          .split('[')
-          .filter((section) => section.startsWith('user]'))
-          .join('[')
-    );
-    if (!user) {
-      return;
-    }
-    await writeFile(
-      join(path, '.git/config'),
-      [ws.substring(1), core, user, ...sections].join(''),
-      'utf-8'
-    );
-  } catch (e) {
-    if (isFileNotFound(e)) {
-      return;
-    }
-    throw e;
-  }
-}
-
-async function makeWindowsDevcontainerFriendly(targetDir: string) {
-  if (!(await stat(join(targetDir, '.gitattributes')).catch(isFileNotFound))) {
-    return;
-  }
-
-  await writeFile(join(targetDir, '.gitattributes'), '* text=auto eol=lf\n');
-  await forEachSourceFile(targetDir, async (path) => {
-    await writeFile(
-      path,
-      (await readFile(path, 'utf-8')).replaceAll(EOL, '\n'),
-      'utf-8'
-    );
-  });
 }
 
 export async function update(targetDir: string) {
   await ensureUnlinked(join(targetDir, '.timestamps.json'));
-}
-
-async function forEachSourceFile(
-  path: string,
-  fn: (p: string) => Promise<void>
-) {
-  const entries = await readdir(path, { withFileTypes: true });
-  await Promise.all(
-    entries.map(async (entry) => {
-      if (entry.isDirectory() && entry.name !== 'node_modules') {
-        await forEachSourceFile(join(path, entry.name), fn);
-      }
-      if (
-        (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) ||
-        entry.name.endsWith('.json')
-      ) {
-        await fn(join(path, entry.name));
-      }
-    })
-  );
 }
 
 async function ensureUnlinked(path: string) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@riddance/env",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "keywords": [
     "riddance",


### PR DESCRIPTION
- Remove Windows support: I dont think anyone uses this, so lets just get rid of it
- Remove git user sync, since it has a few not-obvious assumptions: If no user is found, the git config breaks (also seen on CI)